### PR TITLE
Add Reload method to Jenkins

### DIFF
--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -97,6 +97,15 @@ func (j *Jenkins) Load() {
 	log.Printf("Loaded %v jobs\n", j.jobs.Len())
 }
 
+// Reload runs Load again.
+func (j *Jenkins) Reload(msg synthetic.Message) {
+	msg.React("+1")
+	j.jobs.Clear()
+	j.Load()
+	msg.Reply(fmt.Sprintf("%v Jenkins jobs reloaded", j.jobs.Len()), msg.Thread())
+	msg.React("heavy_check_mark")
+}
+
 // Describe replies `msg` with the description of a job defined.
 func (j *Jenkins) Describe(msg synthetic.Message) {
 	job, _, _, err := j.ParseArgs(msg.ClearMention(), "describe")
@@ -178,4 +187,5 @@ func Register(client *slack.Chat) {
 	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(j.List, "list")))
 	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(j.Describe, "describe")))
 	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(j.Build, "build")))
+	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(j.Reload, "reload")))
 }

--- a/pkg/jenkins/jenkins_test.go
+++ b/pkg/jenkins/jenkins_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestLoad(t *testing.T) {
+func TestLoadReload(t *testing.T) {
 	log.SetFlags(0)
 	log.SetOutput(ioutil.Discard)
 	expectedJobs := map[string]string{
@@ -37,6 +37,34 @@ func TestLoad(t *testing.T) {
 			t.Fail()
 		}
 		i++
+	}
+
+	msg := &MockSyntheticMessage{
+		replies: []string{},
+	}
+
+	j.Reload(msg)
+
+	if j.jobs.Len() != len(expectedJobs) {
+		t.Logf("Wrong number of jobs loaded %v but expected %v", j.jobs.Len(), len(expectedJobs))
+		t.Fail()
+	}
+	i = 0
+	for job := range j.jobs.jobs {
+		if mas.jobs[job] != expectedJobs[job] {
+			t.Logf("Wrong job loaded %v expected %v", mas.jobs[job], expectedJobs[job])
+			t.Fail()
+		}
+		i++
+	}
+	if len(msg.replies) != 1 {
+		t.Logf("Wrong number of replies received %v should be 1", len(msg.replies))
+		t.Fail()
+	}
+	expectedReply := "3 Jenkins jobs reloaded"
+	if msg.replies[0] != expectedReply {
+		t.Logf("Wrong reply '%v' should be '%v'", msg.replies[0], expectedReply)
+		t.Fail()
 	}
 }
 

--- a/pkg/jenkins/jobs.go
+++ b/pkg/jenkins/jobs.go
@@ -37,6 +37,12 @@ func (jobs *Jobs) JobIsPresent(name string) bool {
 	return found
 }
 
+// Clear flushes the job list.
+func (jobs *Jobs) Clear() {
+	jobs.jobs = map[string]func([]string, map[string]string, chan string){}
+	jobs.jobNames = []string{}
+}
+
 // Len provides the amount of jobs.
 func (jobs *Jobs) Len() int {
 	return len(jobs.jobNames)


### PR DESCRIPTION
This method empties the Jobs structure and calls Load again. This is needed to have a
proper job list reload command.