### PR TITLE
Reduce multiple spaces in Jenkins message parsing

### DIFF
--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 
 	jk "github.com/ifosch/jk/pkg/jenkins"
@@ -46,7 +47,8 @@ func (j *Jenkins) Init() (err error) {
 
 // ParseArgs provides parameters and options parsing from a string.
 func (j *Jenkins) ParseArgs(input, command string) (job string, params []string, args map[string]string, err error) {
-	params = strings.Split(slack.RemoveWord(input, command), " ")
+	reduceDupSpaces := regexp.MustCompile(`[ ]{2,}`)
+	params = strings.Split(slack.RemoveWord(reduceDupSpaces.ReplaceAllString(input, " "), command), " ")
 	args = map[string]string{}
 	toRemove := []int{}
 	for i, param := range params {

--- a/pkg/jenkins/jenkins_test.go
+++ b/pkg/jenkins/jenkins_test.go
@@ -8,6 +8,31 @@ import (
 	"testing"
 )
 
+func TestParseArgs(t *testing.T) {
+	log.SetFlags(0)
+	log.SetOutput(ioutil.Discard)
+	expectedJobs := map[string]string{
+		"deploy": "Deploy project",
+	}
+	mas := NewMockAutomationServer(
+		expectedJobs,
+	)
+	j := &Jenkins{
+		jk:   mas,
+		jobs: NewJobs(mas),
+	}
+	j.Load()
+	input := "build  deploy      INDEX=users"
+	command := "build"
+
+	job, _, _, _ := j.ParseArgs(input, command)
+
+	if job != "deploy" {
+		t.Logf("Wrong job parsed '%v' should be 'deploy'", job)
+		t.Fail()
+	}
+}
+
 func TestLoadReload(t *testing.T) {
 	log.SetFlags(0)
 	log.SetOutput(ioutil.Discard)


### PR DESCRIPTION
This prevents the problem when the message on Slack is written with
multiple spaces. There is no need to reduce tabs, as this is not
possible, and it doesn't count new lines, as it might mean different
things and require intention from the user.