### PR TITLE
Provide a MessageProcessor structure to wrap processors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,8 +25,18 @@ func main() {
 	debug := false
 
 	client := slack.NewChat(slackToken, true, debug)
-	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(replyHello, "hello")))
-	client.RegisterMessageProcessor(slack.NotMentioned(slack.Contains(reactHello, "hello")))
+	client.RegisterMessageProcessor(
+		slack.NewMessageProcessor(
+			"github.com/ifosch/synthetic/main.replyHello",
+			slack.Mentioned(slack.Contains(replyHello, "hello")),
+		),
+	)
+	client.RegisterMessageProcessor(
+		slack.NewMessageProcessor(
+			"github.com/ifosch/synthetic/main.reactHello",
+			slack.NotMentioned(slack.Contains(reactHello, "hello")),
+		),
+	)
 
 	jenkins.Register(client)
 

--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -186,8 +186,8 @@ func Register(client *slack.Chat) {
 
 	j.Load()
 
-	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(j.List, "list")))
-	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(j.Describe, "describe")))
-	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(j.Build, "build")))
-	client.RegisterMessageProcessor(slack.Mentioned(slack.Contains(j.Reload, "reload")))
+	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.List", slack.Mentioned(slack.Contains(j.List, "list"))))
+	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.Describe", slack.Mentioned(slack.Contains(j.Describe, "describe"))))
+	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.Build", slack.Mentioned(slack.Contains(j.Build, "build"))))
+	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.Reload", slack.Mentioned(slack.Contains(j.Reload, "reload"))))
 }

--- a/pkg/slack/message_test.go
+++ b/pkg/slack/message_test.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"testing"
 
-	"github.com/ifosch/synthetic/pkg/synthetic"
 	"github.com/slack-go/slack"
 )
 
@@ -83,7 +82,7 @@ func TestReadMessage(t *testing.T) {
 		api:                  client,
 		rtm:                  nil,
 		defaultReplyInThread: false,
-		processors:           map[string][]func(synthetic.Message){},
+		processors:           map[string][]IMessageProcessor{},
 		botID:                "me",
 	}
 	user, _ := NewUserFromID("U000001", client)
@@ -156,7 +155,7 @@ func TestReply(t *testing.T) {
 		api:                  client,
 		rtm:                  rtm,
 		defaultReplyInThread: false,
-		processors:           map[string][]func(synthetic.Message){},
+		processors:           map[string][]IMessageProcessor{},
 		botID:                "me",
 	}
 	messageEvents := messageEvents()
@@ -203,7 +202,7 @@ func TestReactUnreact(t *testing.T) {
 		api:                  client,
 		rtm:                  rtm,
 		defaultReplyInThread: false,
-		processors:           map[string][]func(synthetic.Message){},
+		processors:           map[string][]IMessageProcessor{},
 		botID:                "me",
 	}
 	messageEvents := messageEvents()

--- a/pkg/slack/processor.go
+++ b/pkg/slack/processor.go
@@ -1,0 +1,36 @@
+package slack
+
+import (
+	"github.com/ifosch/synthetic/pkg/synthetic"
+)
+
+// IMessageProcessor is an interface to represent message processor
+// functions.
+type IMessageProcessor interface {
+	Name() string
+	Run(synthetic.Message)
+}
+
+// MessageProcessor is an implementation of IMessageProcessor.
+type MessageProcessor struct {
+	name          string
+	processorFunc func(synthetic.Message)
+}
+
+// NewMessageProcessor is the constructor for MessageProcessor.
+func NewMessageProcessor(name string, processorFunc func(synthetic.Message)) *MessageProcessor {
+	return &MessageProcessor{
+		name:          name,
+		processorFunc: processorFunc,
+	}
+}
+
+// Name returns the name of the MessageProcessor.
+func (mp *MessageProcessor) Name() string {
+	return mp.name
+}
+
+// Run executes the MessageProcessor function.
+func (mp *MessageProcessor) Run(msg synthetic.Message) {
+	mp.processorFunc(msg)
+}


### PR DESCRIPTION
This wrapping allows to include more metadata about the processor,
like the name, removing the need on `reflect` and `runtime`.