### PR TITLE
Fix non-breaking space parsing

### DIFF
--- a/pkg/slack/helpers.go
+++ b/pkg/slack/helpers.go
@@ -4,6 +4,20 @@ import (
 	"strings"
 )
 
+// ReplaceSpace ...
+func ReplaceSpace(s string) string {
+	var result []rune
+	const badSpace = '\u00A0'
+	for _, r := range s {
+		if r == badSpace {
+			result = append(result, '\u0020')
+			continue
+		}
+		result = append(result, r)
+	}
+	return string(result)
+}
+
 // RemoveWord removes `word` from `text` and returns the result. Note
 // this uses a single space to split the words in `text`.
 func RemoveWord(text string, word string) string {

--- a/pkg/slack/message.go
+++ b/pkg/slack/message.go
@@ -72,6 +72,7 @@ func ReadMessage(event *slack.MessageEvent, chat *Chat) (msg *Message, err error
 	if err != nil {
 		return nil, err
 	}
+
 	return &Message{
 		event:        event,
 		chat:         chat,
@@ -80,7 +81,7 @@ func ReadMessage(event *slack.MessageEvent, chat *Chat) (msg *Message, err error
 		mention:      strings.Contains(event.Text, fmt.Sprintf("<@%v>", chat.botID)),
 		user:         user,
 		conversation: conversation,
-		text:         event.Text,
+		text:         ReplaceSpace(event.Text),
 	}, nil
 }
 


### PR DESCRIPTION
When copying messages with mentions from Slack back to it, the copied
text uses a non-breaking space (Unicode \u00a0) right after the
mention. This is not treated like a regular space anymore, so the bot
can't parse the message correctly.

The `RemoveSpace` function iters over the string rebuilding the
string, as it's immutable, and when finds the non-breaking space
unicode, it replaces it with a regular space.