### PR TITLE
Fix simultaneous processor executions

### DIFF
--- a/pkg/job_control/jenkins.go
+++ b/pkg/job_control/jenkins.go
@@ -117,7 +117,7 @@ func Register(client *slack.Chat) {
 		log.Fatalf("Error: %v", err)
 	}
 
-	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.List", slack.Mentioned(slack.Contains(j.List, "list"))))
+	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.List", slack.Exactly(slack.Mentioned(j.List), "list")))
 	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.Describe", slack.Mentioned(slack.Contains(j.Describe, "describe"))))
 	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.Build", slack.Mentioned(slack.Contains(j.Build, "build"))))
 	client.RegisterMessageProcessor(slack.NewMessageProcessor("github.com/ifosch/synthetic/pkg/jenkins.Reload", slack.Mentioned(slack.Contains(j.Reload, "reload"))))

--- a/pkg/slack/filters.go
+++ b/pkg/slack/filters.go
@@ -6,6 +6,16 @@ import (
 	"github.com/ifosch/synthetic/pkg/synthetic"
 )
 
+// Exactly returns a processot that runs the `processor` if the
+// message is exactly like the `catch` string.
+func Exactly(processor func(synthetic.Message), catch string) func(synthetic.Message) {
+	return func(msg synthetic.Message) {
+		if msg.ClearMention() == catch {
+			processor(msg)
+		}
+	}
+}
+
 // Contains returns a processor that runs the `processor` if the
 // message contains the `catch` string.
 func Contains(processor func(synthetic.Message), catch string) func(synthetic.Message) {

--- a/pkg/slack/filters_test.go
+++ b/pkg/slack/filters_test.go
@@ -15,7 +15,7 @@ func (m MockMessage) Reply(msg string, inThread bool) {}
 func (m MockMessage) React(reaction string)           {}
 func (m MockMessage) Unreact(reaction string)         {}
 func (m MockMessage) ClearMention() string {
-	return ""
+	return m.Text()
 }
 func (m MockMessage) Thread() bool {
 	return false
@@ -33,6 +33,23 @@ func (m MockMessage) Conversation() synthetic.Conversation {
 	return nil
 }
 
+func TestExactly(t *testing.T) {
+	calls := 0
+	processor := func(synthetic.Message) {
+		calls++
+	}
+
+	derivedProcessor := Exactly(processor, "test")
+	derivedProcessor(MockMessage{text: "test"})
+	derivedProcessor(MockMessage{text: "test "})
+	derivedProcessor(MockMessage{text: ""})
+
+	if calls != 1 {
+		t.Logf("Wrong number of executions %v should be 1", calls)
+		t.Fail()
+	}
+}
+
 func TestContains(t *testing.T) {
 	calls := 0
 	processor := func(synthetic.Message) {
@@ -41,10 +58,11 @@ func TestContains(t *testing.T) {
 
 	derivedProcessor := Contains(processor, "test")
 	derivedProcessor(MockMessage{text: "test"})
+	derivedProcessor(MockMessage{text: "test "})
 	derivedProcessor(MockMessage{text: ""})
 
-	if calls != 1 {
-		t.Logf("Wrong number of executions %v should be 1", calls)
+	if calls != 2 {
+		t.Logf("Wrong number of executions %v should be 2", calls)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
When receiving a message with two matching hooks both processors are
executed. While this is not really fixing this, as that will require
a lot of refactoring, the fix here is bringing a new filter to exactly
match the hook.