### PR TITLE
Recognise quoted parameters as a single entity

### DIFF
--- a/pkg/job_control/helpers.go
+++ b/pkg/job_control/helpers.go
@@ -1,26 +1,32 @@
 package jobcontrol
 
-// InIntSlice returns true if the `elem` integer is present in
-// `slice`.
-func InIntSlice(slice []int, elem int) bool {
-	found := false
-	for _, i := range slice {
-		if i == elem {
-			found = true
-			break
-		}
-	}
-	return found
-}
+import (
+	"strings"
+	"unicode"
+)
 
-// RemoveIndexes removes the elements in `slice` with the indexes in
-// `indexes`.
-func RemoveIndexes(slice []string, indexes []int) []string {
-	newSlice := []string{}
-	for i, s := range slice {
-		if !InIntSlice(indexes, i) {
-			newSlice = append(newSlice, s)
+func tokenizeParams(input string) []string {
+	// Solution taken from
+	// https://groups.google.com/g/golang-nuts/c/pNwqLyfl2co/m/APaZSSvQUAAJ
+	lastQuote := rune(0)
+	// Must return true for symbols that delimit a field
+	f := func(c rune) bool {
+		switch {
+		case c == lastQuote:
+			// when the quotation ends
+			lastQuote = rune(0)
+			return false
+		case lastQuote != rune(0):
+			//when we are inside a quotation
+			return false
+		case unicode.In(c, unicode.Quotation_Mark):
+			// when c is a valid quotation mark symbol starts a quotation
+			lastQuote = c
+			return false
+		default:
+			return unicode.IsSpace(c)
+
 		}
 	}
-	return newSlice
+	return strings.FieldsFunc(input, f)
 }

--- a/pkg/job_control/jenkins_test.go
+++ b/pkg/job_control/jenkins_test.go
@@ -249,3 +249,45 @@ func TestBuild(t *testing.T) {
 		}
 	}
 }
+
+func TestTokenizeParams(t *testing.T) {
+	tt := []struct {
+		input  string
+		result []string
+	}{
+		{
+			input:  "",
+			result: []string{},
+		},
+		{
+			input:  "build deploy",
+			result: []string{"build", "deploy"},
+		},
+		{
+			input:  "build  deploy      INDEX=users",
+			result: []string{"build", "deploy", "INDEX=users"},
+		},
+		{
+			input:  "build  deploy      INDEX=\"users\"",
+			result: []string{"build", "deploy", "INDEX=\"users\""},
+		},
+		{
+			input:  "build  deploy      INDEX=\"users ducks\"",
+			result: []string{"build", "deploy", "INDEX=\"users ducks\""},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.input, func(t *testing.T) {
+			result := tokenizeParams(tc.input)
+			if len(result) != len(tc.result) {
+				t.Errorf("expected %d results but got %d", len(tc.result), len(result))
+			}
+
+			for i, value := range result {
+				if value != tc.result[i] {
+					t.Errorf("expected element %d to be %s but was %s", i, tc.result[i], value)
+				}
+			}
+		})
+	}
+}

--- a/pkg/job_control/jenkins_test.go
+++ b/pkg/job_control/jenkins_test.go
@@ -43,6 +43,13 @@ func TestParsing(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			input:         "build  deploy INDEX=\"users ducks\"",
+			command:       "build",
+			expectedJob:   "deploy",
+			expectedArgs:  map[string]string{"INDEX": "\"users ducks\""},
+			expectedError: "",
+		},
+		{
 			input:         "describe",
 			command:       "describe",
 			expectedJob:   "",

--- a/pkg/job_control/jenkins_test.go
+++ b/pkg/job_control/jenkins_test.go
@@ -52,27 +52,35 @@ func TestParsing(t *testing.T) {
 		{
 			input:         "describe missingjob",
 			command:       "describe",
-			expectedJob:   "missingjob",
+			expectedJob:   "", // Job does not exist so it returns empty
 			expectedArgs:  map[string]string{},
 			expectedError: "the job `missingjob` doesn't exist in current job list. If it's new addition, try using `reload` to refresh the list of jobs",
 		},
 	}
 
 	for _, test := range tcs {
-		job, args, err := j.ParseArgs(test.input, test.command)
+		t.Run(test.input, func(t *testing.T) {
+			job, args, err := j.ParseArgs(test.input, test.command)
 
-		if err != nil {
-			if test.expectedError == "" {
+			// Unexpected error happened
+			if test.expectedError == "" && err != nil {
 				t.Logf("Unexpected error %v", err)
 				t.Fail()
 			}
-		} else if test.expectedError != "" {
-			t.Logf("Expected error '%v' didn't happened", test.expectedError)
-			t.Fail()
+
+			// Expected error did not happen
+			if test.expectedError != "" && err == nil {
+				t.Logf("Expected error '%v' didn't happen", test.expectedError)
+				t.Fail()
+			}
+
+			// Job parsing did not match.
 			if job != test.expectedJob {
 				t.Logf("Wrong job parsed '%v' should be '%v'", job, test.expectedJob)
 				t.Fail()
 			}
+
+			// Parsed arguments did not match
 			for expectedName, expectedValue := range test.expectedArgs {
 				value, ok := args[expectedName]
 				if !ok {
@@ -84,7 +92,7 @@ func TestParsing(t *testing.T) {
 					t.Fail()
 				}
 			}
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
All tokenization operations treat whitespace as the delimiter, but in
some cases it is interesting to allow whitespace inside one token. In
those cases, the usual solution is to quote around the token.

This PR adds a tokenization function that identifies quotations and
treats them as a single unit, allowing them to contain whitespace. It
also fixes and clarifies the tests for the parsing function before
extending them to cover this new case.

Fixes #19

---

**Fix parsing tests**
The parsing tests would fail immediately if an error was expected, so
the value of the job return value or the arguments was never checked.

Fix the test logic to verify all return values in all cases and
introduce subtests for cleaner output when one of them fails. This
change caused one of the non-run tests to fail, because the parsing
fails and then no job value is returned. Fix the data for that test
and add a comment explaining the reson for the data in the test input.

**Use tokenizer aware of quotations**
Add a new tokenizer function that respects quoted elements as a single
group and use it when parsing arguments. Also adjust the rest of the
function to reduce iterations and data structures.

**Add test to parse quoted parameters**
Add a test case for ParseArgs using a quoted parameter.