### PR TITLE
Add new step to CI to run staticcheck

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,7 +111,10 @@ jobs:
         name: Install ineffassign
         run: |
           go get -u github.com/gordonklaus/ineffassign
-          go get golang.org/x/net/html
+      -
+        name: Download dependencies to local
+        run : |
+          go mod download
       -
         name: Check ineffectual assignments
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -138,6 +138,29 @@ jobs:
         name: Check spelling
         run: |
           misspell -error .
+  staticcheck:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      -
+        name: Install staticcheck
+        run: |
+          go get -u honnef.co/go/tools/cmd/staticcheck@latest
+      -
+        name: Download dependencies to local
+        run : |
+          go mod download
+      -
+        name: Run staticcheck
+        run: |
+          staticcheck ./...
   check-license:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      -
         name: Check code smells
         run: |
           go vet ./...

--- a/pkg/job_control/jenkins_job.go
+++ b/pkg/job_control/jenkins_job.go
@@ -107,7 +107,7 @@ func DescribeTemplate() (t *template.Template, err error) {
 		"trim": trim,
 	}).Parse(tmpl)
 	if err != nil {
-		return nil, fmt.Errorf("Template Creation error %v", err)
+		return nil, fmt.Errorf("template Creation error %v", err)
 	}
 	return t, nil
 }


### PR DESCRIPTION
Add statichceck as an extra linter in the CI so we can ctch more
defects early.

---

**ci: Ensure Go version running `vet`**
As `go vet` is supplied by the tooling it is different depending on
the Go version installed. Ensure the proper version is installed, as
we do with the rest of steps.

**ci: Add staticcheck linter**
Add a staticcheck test to repo.