### PR TITLE
Return the connection error from jenkins

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,9 @@ func main() {
 		os.Getenv("JENKINS_USER"),
 		os.Getenv("JENKINS_PASSWORD"),
 	)
+	if err := jenkins.Connect(); err != nil {
+		log.Fatalf("error connecting to jenkins: %s", err.Error())
+	}
 	registerJenkinsCommands(client, jenkins)
 
 	registerK8sCommands(client)

--- a/pkg/job_control/jenkins.go
+++ b/pkg/job_control/jenkins.go
@@ -9,15 +9,22 @@ import (
 
 // Jenkins is the object to handle the Jenkins connection.
 type Jenkins struct {
-	js IJobServer
+	url, user, password string
+	js                  IJobServer
 }
 
 // NewJenkins returns a pointer to an initialized Jenkins instance
 func NewJenkins(url, user, password string) *Jenkins {
-	j := &Jenkins{}
+	j := &Jenkins{url: url, user: user, password: password}
 	j.js = &JenkinsJobServer{}
-	j.js.Connect(url, user, password)
 	return j
+}
+
+// Connect to the jenkins server with the credentials used during
+// initialization
+func (j *Jenkins) Connect() error {
+	j.js.Connect(j.url, j.user, j.password)
+	return nil
 }
 
 // ParseArgs provides parameters and options parsing from a message.


### PR DESCRIPTION
The possible error return from a jenkins connection was ignored
before. Now we make it explicitly available and displayed to the user
if there's a failure during initialization.

This should also allow to implement connection retries and
reconnection attempts when needed.