### PR TITLE
Improve tests on slack package

### DIFF
--- a/pkg/slack/conversation_test.go
+++ b/pkg/slack/conversation_test.go
@@ -13,14 +13,16 @@ func TestNewConversationFromID(t *testing.T) {
 
 	client := NewMockClient()
 	for testID, data := range tc {
-		conversation, err := NewConversationFromID(data[0], client)
-		if err != nil {
-			t.Logf("NewConversationFromID errored for %v: %v", testID, err)
-			t.Fail()
-		}
-		if conversation.name != data[1] {
-			t.Logf("Conversation name was %v, instead of expected %v", conversation.name, data[1])
-			t.Fail()
-		}
+		t.Run(testID, func(t *testing.T) {
+			conversation, err := NewConversationFromID(data[0], client)
+			if err != nil {
+				t.Logf("NewConversationFromID errored for %v: %v", testID, err)
+				t.Fail()
+			}
+			if conversation.name != data[1] {
+				t.Logf("Conversation name was %v, instead of expected %v", conversation.name, data[1])
+				t.Fail()
+			}
+		})
 	}
 }

--- a/pkg/slack/filters_test.go
+++ b/pkg/slack/filters_test.go
@@ -16,31 +16,33 @@ func TestExactly(t *testing.T) {
 	processor := func(synthetic.Message) {
 		calls++
 	}
-	tcs := []filtersTC{
-		{
+	tcs := map[string]filtersTC{
+		"one call": {
 			message:       synthetic.NewMockMessage("test", false),
 			expectedCalls: 1,
 		},
-		{
+		"no calls": {
 			message:       synthetic.NewMockMessage("test ", false),
 			expectedCalls: 0,
 		},
-		{
+		"empty message": {
 			message:       synthetic.NewMockMessage("", false),
 			expectedCalls: 0,
 		},
 	}
 
 	derivedProcessor := Exactly(processor, "test")
-	for _, tc := range tcs {
-		calls = 0
+	for testID, tc := range tcs {
+		t.Run(testID, func(t *testing.T) {
+			calls = 0
 
-		derivedProcessor(tc.message)
+			derivedProcessor(tc.message)
 
-		if calls != tc.expectedCalls {
-			t.Logf("Wrong number of executions %v should be %v", calls, tc.expectedCalls)
-			t.Fail()
-		}
+			if calls != tc.expectedCalls {
+				t.Logf("Wrong number of executions %v should be %v", calls, tc.expectedCalls)
+				t.Fail()
+			}
+		})
 	}
 }
 
@@ -49,31 +51,29 @@ func TestContains(t *testing.T) {
 	processor := func(synthetic.Message) {
 		calls++
 	}
-	tcs := []filtersTC{
-		{
+	tcs := map[string]filtersTC{
+		"one call": {
 			message:       synthetic.NewMockMessage("test", false),
 			expectedCalls: 1,
 		},
-		{
-			message:       synthetic.NewMockMessage("test ", false),
-			expectedCalls: 1,
-		},
-		{
+		"no calls": {
 			message:       synthetic.NewMockMessage("", false),
 			expectedCalls: 0,
 		},
 	}
 
 	derivedProcessor := Contains(processor, "test")
-	for _, tc := range tcs {
-		calls = 0
+	for testID, tc := range tcs {
+		t.Run(testID, func(t *testing.T) {
+			calls = 0
 
-		derivedProcessor(tc.message)
+			derivedProcessor(tc.message)
 
-		if calls != tc.expectedCalls {
-			t.Logf("Wrong number of executions %v should be %v", calls, tc.expectedCalls)
-			t.Fail()
-		}
+			if calls != tc.expectedCalls {
+				t.Logf("Wrong number of executions %v should be %v", calls, tc.expectedCalls)
+				t.Fail()
+			}
+		})
 	}
 }
 
@@ -82,27 +82,29 @@ func TestMentioned(t *testing.T) {
 	processor := func(synthetic.Message) {
 		calls++
 	}
-	tcs := []filtersTC{
-		{
+	tcs := map[string]filtersTC{
+		"no calls": {
 			message:       synthetic.NewMockMessage("", false),
 			expectedCalls: 0,
 		},
-		{
+		"one call": {
 			message:       synthetic.NewMockMessage("", true),
 			expectedCalls: 1,
 		},
 	}
 
 	derivedProcessor := Mentioned(processor)
-	for _, tc := range tcs {
-		calls = 0
+	for testID, tc := range tcs {
+		t.Run(testID, func(t *testing.T) {
+			calls = 0
 
-		derivedProcessor(tc.message)
+			derivedProcessor(tc.message)
 
-		if calls != tc.expectedCalls {
-			t.Logf("Wrong number of executions %v should be %v", calls, tc.expectedCalls)
-			t.Fail()
-		}
+			if calls != tc.expectedCalls {
+				t.Logf("Wrong number of executions %v should be %v", calls, tc.expectedCalls)
+				t.Fail()
+			}
+		})
 	}
 }
 
@@ -111,26 +113,28 @@ func TestNotMentioned(t *testing.T) {
 	processor := func(synthetic.Message) {
 		calls++
 	}
-	tcs := []filtersTC{
-		{
+	tcs := map[string]filtersTC{
+		"one call": {
 			message:       synthetic.NewMockMessage("", false),
 			expectedCalls: 1,
 		},
-		{
+		"no calls": {
 			message:       synthetic.NewMockMessage("", true),
 			expectedCalls: 0,
 		},
 	}
 
 	derivedProcessor := NotMentioned(processor)
-	for _, tc := range tcs {
-		calls = 0
+	for testID, tc := range tcs {
+		t.Run(testID, func(t *testing.T) {
+			calls = 0
 
-		derivedProcessor(tc.message)
+			derivedProcessor(tc.message)
 
-		if calls != tc.expectedCalls {
-			t.Logf("Wrong number of executions %v should be %v", calls, tc.expectedCalls)
-			t.Fail()
-		}
+			if calls != tc.expectedCalls {
+				t.Logf("Wrong number of executions %v should be %v", calls, tc.expectedCalls)
+				t.Fail()
+			}
+		})
 	}
 }

--- a/pkg/slack/message_test.go
+++ b/pkg/slack/message_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/slack-go/slack"
 )
 
-func messageEvents() []*slack.MessageEvent {
-	return []*slack.MessageEvent{
-		{
+func messageEvents() map[string]*slack.MessageEvent {
+	return map[string]*slack.MessageEvent{
+		"uninitialized message": {
 			Msg: slack.Msg{
 				ClientMsgID:     "",
 				ThreadTimestamp: "",
@@ -17,7 +17,7 @@ func messageEvents() []*slack.MessageEvent {
 				Text:            "",
 			},
 		},
-		{
+		"empty message in thread": {
 			Msg: slack.Msg{
 				ClientMsgID:     "M000001",
 				ThreadTimestamp: "165783949832",
@@ -26,7 +26,7 @@ func messageEvents() []*slack.MessageEvent {
 				Text:            "",
 			},
 		},
-		{
+		"empty message no thread": {
 			Msg: slack.Msg{
 				ClientMsgID:     "M000001",
 				ThreadTimestamp: "",
@@ -35,7 +35,7 @@ func messageEvents() []*slack.MessageEvent {
 				Text:            "",
 			},
 		},
-		{
+		"only mention no thread": {
 			Msg: slack.Msg{
 				ClientMsgID:     "M000001",
 				ThreadTimestamp: "",
@@ -59,38 +59,40 @@ func TestReply(t *testing.T) {
 	}
 	messageEvents := messageEvents()
 
-	for _, messageEvent := range messageEvents {
-		message, err := chat.ReadMessage(messageEvent)
-		if err != nil {
-			t.Logf("ReadMessage errored: %v", err)
-			t.Fail()
-		}
-		message.Reply("reply", false)
-		if len(rtm.messagesSent) != 1 {
-			t.Logf("I've sent only one message, but %v were detected", len(rtm.messagesSent))
-			t.Fail()
-		}
-		reply := rtm.messagesSent[0]
-		if message.Completed {
-			if reply.Channel != message.conversation.slackChannel.ID {
-				t.Logf("Wrong channel ID used in reply %v should be %v", reply.Channel, message.conversation.slackChannel.ID)
+	for testID, messageEvent := range messageEvents {
+		t.Run(testID, func(t *testing.T) {
+			message, err := chat.ReadMessage(messageEvent)
+			if err != nil {
+				t.Logf("ReadMessage errored: %v", err)
 				t.Fail()
 			}
-			if reply.Text != "reply" {
-				t.Logf("Wrong text in reply %v should be reply", reply.Text)
+			message.Reply("reply", false)
+			if len(rtm.messagesSent) != 1 {
+				t.Logf("I've sent only one message, but %v were detected", len(rtm.messagesSent))
 				t.Fail()
 			}
-			if reply.ThreadTimestamp != message.event.ThreadTimestamp {
-				t.Logf("Wrong timestamp in reply %v should be %v", reply.ThreadTimestamp, message.event.ThreadTimestamp)
-				t.Fail()
+			reply := rtm.messagesSent[0]
+			if message.Completed {
+				if reply.Channel != message.conversation.slackChannel.ID {
+					t.Logf("Wrong channel ID used in reply %v should be %v", reply.Channel, message.conversation.slackChannel.ID)
+					t.Fail()
+				}
+				if reply.Text != "reply" {
+					t.Logf("Wrong text in reply %v should be reply", reply.Text)
+					t.Fail()
+				}
+				if reply.ThreadTimestamp != message.event.ThreadTimestamp {
+					t.Logf("Wrong timestamp in reply %v should be %v", reply.ThreadTimestamp, message.event.ThreadTimestamp)
+					t.Fail()
+				}
+			} else {
+				if reply.Channel != "" {
+					t.Logf("Incomplete message should have a nil reply but got %v", reply)
+					t.Fail()
+				}
 			}
-		} else {
-			if reply.Channel != "" {
-				t.Logf("Incomplete message should have a nil reply but got %v", reply)
-				t.Fail()
-			}
-		}
-		rtm.reset()
+			rtm.reset()
+		})
 	}
 }
 
@@ -99,42 +101,44 @@ func TestReactUnreact(t *testing.T) {
 	chat := NewChat(client, false, "me")
 	messageEvents := messageEvents()
 
-	for _, messageEvent := range messageEvents {
-		message, err := chat.ReadMessage(messageEvent)
-		if err != nil {
-			t.Logf("ReadMessage errored: %v", err)
-			t.Fail()
-		}
-		message.React("+1")
-		if message.Completed {
-			if client.reactionsAdded[0].reaction != "+1" {
-				t.Logf("Wrong reaction %v when adding reaction, should be +1", client.reactionsAdded[0].reaction)
+	for testID, messageEvent := range messageEvents {
+		t.Run(testID, func(t *testing.T) {
+			message, err := chat.ReadMessage(messageEvent)
+			if err != nil {
+				t.Logf("ReadMessage errored: %v", err)
 				t.Fail()
 			}
-			if client.reactionsAdded[0].item.Channel != message.event.Channel {
-				t.Logf("Wrong channel %v when adding reaction, should be %v", client.reactionsAdded[0].item.Channel, message.event.Channel)
-				t.Fail()
+			message.React("+1")
+			if message.Completed {
+				if client.reactionsAdded[0].reaction != "+1" {
+					t.Logf("Wrong reaction %v when adding reaction, should be +1", client.reactionsAdded[0].reaction)
+					t.Fail()
+				}
+				if client.reactionsAdded[0].item.Channel != message.event.Channel {
+					t.Logf("Wrong channel %v when adding reaction, should be %v", client.reactionsAdded[0].item.Channel, message.event.Channel)
+					t.Fail()
+				}
+				if client.reactionsAdded[0].item.Timestamp != message.event.Timestamp {
+					t.Logf("Wrong timestamp %v when adding reaction, should be %v", client.reactionsAdded[0].item.Timestamp, message.event.Timestamp)
+					t.Fail()
+				}
 			}
-			if client.reactionsAdded[0].item.Timestamp != message.event.Timestamp {
-				t.Logf("Wrong timestamp %v when adding reaction, should be %v", client.reactionsAdded[0].item.Timestamp, message.event.Timestamp)
-				t.Fail()
+			message.Unreact("+1")
+			if message.Completed {
+				if client.reactionsRemoved[0].reaction != "+1" {
+					t.Logf("Wrong reaction %v when removing reaction, should be +1", client.reactionsRemoved[0].reaction)
+					t.Fail()
+				}
+				if client.reactionsRemoved[0].item.Channel != message.event.Channel {
+					t.Logf("Wrong channel %v when removing reaction, should be %v", client.reactionsRemoved[0].item.Channel, message.event.Channel)
+					t.Fail()
+				}
+				if client.reactionsRemoved[0].item.Timestamp != message.event.Timestamp {
+					t.Logf("Wrong timestamp %v when removing reaction, should be %v", client.reactionsRemoved[0].item.Timestamp, message.event.Timestamp)
+					t.Fail()
+				}
 			}
-		}
-		message.Unreact("+1")
-		if message.Completed {
-			if client.reactionsRemoved[0].reaction != "+1" {
-				t.Logf("Wrong reaction %v when removing reaction, should be +1", client.reactionsRemoved[0].reaction)
-				t.Fail()
-			}
-			if client.reactionsRemoved[0].item.Channel != message.event.Channel {
-				t.Logf("Wrong channel %v when removing reaction, should be %v", client.reactionsRemoved[0].item.Channel, message.event.Channel)
-				t.Fail()
-			}
-			if client.reactionsRemoved[0].item.Timestamp != message.event.Timestamp {
-				t.Logf("Wrong timestamp %v when removing reaction, should be %v", client.reactionsRemoved[0].item.Timestamp, message.event.Timestamp)
-				t.Fail()
-			}
-		}
-		client.reset()
+			client.reset()
+		})
 	}
 }

--- a/pkg/slack/message_test.go
+++ b/pkg/slack/message_test.go
@@ -6,35 +6,6 @@ import (
 	"github.com/slack-go/slack"
 )
 
-type EventMessageCase struct {
-	event    *slack.MessageEvent
-	expected *Message
-}
-
-func sameConversations(a, b *Conversation) bool {
-	if a != nil && b != nil && a.Name() == b.Name() {
-		return true
-	}
-	return false
-}
-
-func sameUsers(a, b *User) bool {
-	if a != nil && b != nil && a.Name() == b.Name() {
-		return true
-	}
-	return false
-}
-
-func sameMessages(a, b *Message) bool {
-	if a != nil && b != nil {
-		return true
-	}
-	if a.Completed != b.Completed || a.thread != b.thread || a.mention != b.mention || !sameUsers(a.user, b.user) || !sameConversations(a.conversation, b.conversation) || a.text != b.text {
-		return false
-	}
-	return true
-}
-
 func messageEvents() []*slack.MessageEvent {
 	return []*slack.MessageEvent{
 		{

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -92,6 +92,35 @@ func TestRegisterMessageProcessor(t *testing.T) {
 	}
 }
 
+type EventMessageCase struct {
+	event    s.MessageEvent
+	expected Message
+}
+
+func sameConversations(a, b *Conversation) bool {
+	if a != nil && b != nil && a.Name() == b.Name() {
+		return true
+	}
+	return false
+}
+
+func sameUsers(a, b *User) bool {
+	if a != nil && b != nil && a.Name() == b.Name() {
+		return true
+	}
+	return false
+}
+
+func sameMessages(a, b *Message) bool {
+	if a != nil && b != nil {
+		return true
+	}
+	if a.Completed != b.Completed || a.thread != b.thread || a.mention != b.mention || !sameUsers(a.user, b.user) || !sameConversations(a.conversation, b.conversation) || a.text != b.text {
+		return false
+	}
+	return true
+}
+
 func TestReadMessage(t *testing.T) {
 	client := NewMockClient()
 	chat := &Chat{

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -20,11 +20,8 @@ func TestProcess(t *testing.T) {
 	disableLogs()
 	client := NewMockClient()
 	processedMessages := 0
-	c := &Chat{
-		api:        client,
-		processors: map[string][]IMessageProcessor{},
-		botID:      "me",
-	}
+	c := NewChat(client, false, "me")
+
 	c.RegisterMessageProcessor(
 		NewMessageProcessor(
 			"github.com/ifosch/synthetic/pkg/slack.CountProcessedMessages",
@@ -75,9 +72,7 @@ func TestProcess(t *testing.T) {
 
 func TestRegisterMessageProcessor(t *testing.T) {
 	disableLogs()
-	c := &Chat{
-		processors: map[string][]IMessageProcessor{},
-	}
+	c := NewChat(NewMockClient(), false, "")
 
 	c.RegisterMessageProcessor(
 		NewMessageProcessor(

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -89,7 +89,7 @@ func TestRegisterMessageProcessor(t *testing.T) {
 }
 
 type EventMessageCase struct {
-	event    *s.MessageEvent
+	event    s.MessageEvent
 	expected Message
 }
 
@@ -139,7 +139,7 @@ func TestReadMessage(t *testing.T) {
 	messageEvents := messageEvents()
 	tc := map[string]*EventMessageCase{
 		// "Incomplete message": {
-		// 	event: messageEvents[0],
+		// 	event: *messageEvents["uninitialized message"],
 		// 	expected: Message{
 		// 		Completed:    false,
 		// 		thread:       false,
@@ -150,7 +150,7 @@ func TestReadMessage(t *testing.T) {
 		// 	},
 		// },
 		"Threaded message": {
-			event: messageEvents[1],
+			event: *messageEvents["empty message in thread"],
 			expected: Message{
 				Completed:    true,
 				thread:       true,
@@ -161,7 +161,7 @@ func TestReadMessage(t *testing.T) {
 			},
 		},
 		"Non-threaded message": {
-			event: messageEvents[2],
+			event: *messageEvents["empty message no thread"],
 			expected: Message{
 				Completed:    true,
 				thread:       false,
@@ -172,7 +172,7 @@ func TestReadMessage(t *testing.T) {
 			},
 		},
 		"Message with mention": {
-			event: messageEvents[3],
+			event: *messageEvents["only mention no thread"],
 			expected: Message{
 				Completed:    true,
 				thread:       false,
@@ -186,7 +186,7 @@ func TestReadMessage(t *testing.T) {
 
 	for testID, data := range tc {
 		t.Run(testID, func(t *testing.T) {
-			message, err := chat.ReadMessage(data.event)
+			message, err := chat.ReadMessage(&data.event)
 			if err != nil {
 				t.Logf("ReadMessage errored for %v: %v", testID, err)
 				t.Fail()


### PR DESCRIPTION
Improve the tests on the slack package, and fix one that was not
working properly.

I had to comment-out a test case as it's very hard to fix, and it
maybe it should be an error-case instead.

---

**Use subtests where possible**
As we are already using test cases, use a subtest for each test case
and add a name for each case, so in case it fails it is easier to find
out which one and why.

**Move leftover helpers for ReadMessage**
When we moved `ReadMessage()` to be a method of `Chat` we did not move
the helpers only used by that test from the message_test.go file.

**Use NewChat in test setup when possible**
We should be using the initializer whenever our tests do not need to
much around with internal state. That way, changes to the initializer
or the Chat struct will only affect the tests that actually care about
those changes.

**Pass test cases by value instead of pointer**
The test cases are better passed by value than pointer, as with
pointers we can get into situations where the test fails to be
properly run due to an oversight.

This is an example of such case: In
d4009a2 we changed the behaviour of
`ReadMessage()` so mentions would no longer appear in the `text` field
of `Message` and we do not need consumers to do the cleanup
themselves. The tests still expect the mention to be present in the
output `text` field, but they do not fail, making the tests
unreliable.

This change would make the tests fail in the first testcase, and in
the last one (the one with a mention) so we comment-out the first and
adjust the last one.

**Use subtests wherever messageEvents are used**
We change the messageEvents structure so each event has an associated
name describing it. We use this name directly in subtests that work
with the events, and to map into the `ReadMessage()` tests. Also
remove the unneeded pointer in `EventMessageCase`.

