### PR TITLE
Improve jobcontrol.Job tests

### DIFF
--- a/pkg/job_control/jenkins_job_test.go
+++ b/pkg/job_control/jenkins_job_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 type jenkinsJobTC struct {
-	input       string
 	name        string
 	description string
 	params      []struct {
@@ -72,9 +71,8 @@ func (tc jenkinsJobTC) getJenkinsJob() *gojenkins.Job {
 }
 
 func TestJob(t *testing.T) {
-	tcs := []jenkinsJobTC{
-		{
-			input:       "Simple job without params",
+	tcs := map[string]jenkinsJobTC{
+		"Simple job without params": {
 			name:        "myjob",
 			description: "myjob does something",
 			params: []struct {
@@ -84,8 +82,7 @@ func TestJob(t *testing.T) {
 				DefaultValue string
 			}{},
 		},
-		{
-			input:       "Simple job with one param",
+		"Simple job with one param": {
 			name:        "myjob",
 			description: "myjob does something",
 			params: []struct {
@@ -104,8 +101,8 @@ func TestJob(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
-		t.Run(tc.input, func(t *testing.T) {
+	for testID, tc := range tcs {
+		t.Run(testID, func(t *testing.T) {
 			j := &Job{
 				jenkinsJob: tc.getJenkinsJob(),
 			}

--- a/pkg/job_control/jenkins_job_test.go
+++ b/pkg/job_control/jenkins_job_test.go
@@ -1,84 +1,128 @@
 package jobcontrol
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bndr/gojenkins"
 )
 
 type jenkinsJobTC struct {
-	input            string
-	job              *gojenkins.Job
-	expectedDescribe string
+	input       string
+	name        string
+	description string
+	params      []struct {
+		Name         string
+		Type         string
+		Description  string
+		DefaultValue string
+	}
+}
+
+func (tc jenkinsJobTC) Describe() string {
+	expectedDescription := fmt.Sprintf(
+		"`%s`: %s\nParameters:\n",
+		tc.name,
+		tc.description,
+	)
+
+	for _, param := range tc.params {
+		expectedDescription += fmt.Sprintf(
+			"- *%s* (%s): %s (Default: `%s`)\n",
+			param.Name,
+			param.Type,
+			param.Description,
+			param.DefaultValue,
+		)
+	}
+
+	return expectedDescription
+}
+
+func (tc jenkinsJobTC) getJenkinsJob() *gojenkins.Job {
+	parameterDefinitions := []gojenkins.ParameterDefinition{}
+	for _, param := range tc.params {
+		parameterDefinition := gojenkins.ParameterDefinition{
+			Description: param.Description,
+			Name:        param.Name,
+			Type:        param.Type,
+			DefaultParameterValue: struct {
+				Name  string      `json:"name"`
+				Value interface{} `json:"value"`
+			}{
+				Name:  "",
+				Value: param.DefaultValue,
+			},
+		}
+		parameterDefinitions = append(parameterDefinitions, parameterDefinition)
+	}
+	return &gojenkins.Job{
+		Raw: &gojenkins.JobResponse{
+			Name:        tc.name,
+			Description: tc.description,
+			Property: []struct {
+				ParameterDefinitions []gojenkins.ParameterDefinition `json:"parameterDefinitions"`
+			}{
+				{
+					ParameterDefinitions: parameterDefinitions,
+				},
+			},
+		},
+	}
 }
 
 func TestJob(t *testing.T) {
 	tcs := []jenkinsJobTC{
 		{
-			input: "Simple job without params",
-			job: &gojenkins.Job{
-				Raw: &gojenkins.JobResponse{
-					Name:        "myjob",
-					Description: "myjob does something",
-				},
-			},
-			expectedDescribe: "`myjob`" + `: myjob does something
-Parameters:
-`,
+			input:       "Simple job without params",
+			name:        "myjob",
+			description: "myjob does something",
+			params: []struct {
+				Name         string
+				Type         string
+				Description  string
+				DefaultValue string
+			}{},
 		},
 		{
-			input: "Simple job with one param",
-			job: &gojenkins.Job{
-				Raw: &gojenkins.JobResponse{
-					Name:        "myjob",
-					Description: "myjob does something",
-					Property: []struct {
-						ParameterDefinitions []gojenkins.ParameterDefinition `json:"parameterDefinitions"`
-					}{
-						{
-							ParameterDefinitions: []gojenkins.ParameterDefinition{
-								{
-									Description: "myParam helps parametrize myjob",
-									Name:        "myParam",
-									Type:        "StringParameterDefinition",
-									DefaultParameterValue: struct {
-										Name  string      `json:"name"`
-										Value interface{} `json:"value"`
-									}{
-										"myParam",
-										"all",
-									},
-								},
-							},
-						},
-					},
+			input:       "Simple job with one param",
+			name:        "myjob",
+			description: "myjob does something",
+			params: []struct {
+				Name         string
+				Type         string
+				Description  string
+				DefaultValue string
+			}{
+				{
+					Name:         "myParam",
+					Type:         "StringParameterDefinition",
+					Description:  "myParam helps parametrize myjob",
+					DefaultValue: "all",
 				},
 			},
-			expectedDescribe: "`myjob`" + `: myjob does something
-Parameters:
-- *myParam* (StringParameterDefinition): myParam helps parametrize myjob (Default: ` + "`all`)\n",
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.input, func(t *testing.T) {
 			j := &Job{
-				jenkinsJob: tc.job,
+				jenkinsJob: tc.getJenkinsJob(),
 			}
 
 			name := j.Name()
-			if name != tc.job.Raw.Name {
-				t.Errorf("Wrong job name '%v' should be '%v'", name, tc.job.Raw.Name)
+			if name != tc.name {
+				t.Errorf("Wrong job name '%v' should be '%v'", name, tc.name)
 			}
 
 			description := j.Description()
-			if description != tc.job.Raw.Description {
-				t.Errorf("Wrong job description '%v' should be '%v'", description, tc.job.Raw.Description)
+			if description != tc.description {
+				t.Errorf("Wrong job description '%v' should be '%v'", description, tc.description)
 			}
 
 			describe := j.Describe()
-			if describe != tc.expectedDescribe {
-				t.Errorf("Wrong job describe '%v' should be '%v'", describe, tc.expectedDescribe)
+			if describe != tc.Describe() {
+				t.Errorf("Wrong job describe '%v' should be '%v'", describe, tc.Describe())
 			}
 		})
 	}

--- a/pkg/job_control/jenkins_job_test.go
+++ b/pkg/job_control/jenkins_job_test.go
@@ -7,37 +7,79 @@ import (
 )
 
 type jenkinsJobTC struct {
+	input            string
 	job              *gojenkins.Job
 	expectedDescribe string
 }
 
 func TestJob(t *testing.T) {
-	tc := jenkinsJobTC{
-		job: &gojenkins.Job{
-			Raw: &gojenkins.JobResponse{
-				Name:        "myjob",
-				Description: "myjob does something",
+	tcs := []jenkinsJobTC{
+		{
+			input: "Simple job without params",
+			job: &gojenkins.Job{
+				Raw: &gojenkins.JobResponse{
+					Name:        "myjob",
+					Description: "myjob does something",
+				},
 			},
+			expectedDescribe: "`myjob`" + `: myjob does something
+Parameters:
+`,
 		},
-		expectedDescribe: "`myjob`: myjob does something\nParameters:\n",
-	}
-	j := &Job{
-		jenkinsJob: tc.job,
+		{
+			input: "Simple job with one param",
+			job: &gojenkins.Job{
+				Raw: &gojenkins.JobResponse{
+					Name:        "myjob",
+					Description: "myjob does something",
+					Property: []struct {
+						ParameterDefinitions []gojenkins.ParameterDefinition `json:"parameterDefinitions"`
+					}{
+						{
+							ParameterDefinitions: []gojenkins.ParameterDefinition{
+								{
+									Description: "myParam helps parametrize myjob",
+									Name:        "myParam",
+									Type:        "StringParameterDefinition",
+									DefaultParameterValue: struct {
+										Name  string      `json:"name"`
+										Value interface{} `json:"value"`
+									}{
+										"myParam",
+										"all",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDescribe: "`myjob`" + `: myjob does something
+Parameters:
+- *myParam* (StringParameterDefinition): myParam helps parametrize myjob (Default: ` + "`all`)\n",
+		},
 	}
 
-	name := j.Name()
+	for _, tc := range tcs {
+		t.Run(tc.input, func(t *testing.T) {
+			j := &Job{
+				jenkinsJob: tc.job,
+			}
 
-	description := j.Description()
+			name := j.Name()
+			if name != tc.job.Raw.Name {
+				t.Errorf("Wrong job name '%v' should be '%v'", name, tc.job.Raw.Name)
+			}
 
-	describe := j.Describe()
+			description := j.Description()
+			if description != tc.job.Raw.Description {
+				t.Errorf("Wrong job description '%v' should be '%v'", description, tc.job.Raw.Description)
+			}
 
-	if name != tc.job.Raw.Name {
-		t.Errorf("Wrong job name '%v' should be '%v'", name, tc.job.Raw.Name)
-	}
-	if description != tc.job.Raw.Description {
-		t.Errorf("Wrong job description '%v' should be '%v'", description, tc.job.Raw.Description)
-	}
-	if describe != tc.expectedDescribe {
-		t.Errorf("Wrong job describe '%v' should be '%v'", describe, tc.expectedDescribe)
+			describe := j.Describe()
+			if describe != tc.expectedDescribe {
+				t.Errorf("Wrong job describe '%v' should be '%v'", describe, tc.expectedDescribe)
+			}
+		})
 	}
 }

--- a/pkg/job_control/jenkins_job_test.go
+++ b/pkg/job_control/jenkins_job_test.go
@@ -32,15 +32,12 @@ func TestJob(t *testing.T) {
 	describe := j.Describe()
 
 	if name != tc.job.Raw.Name {
-		t.Logf("Wrong job name '%v' should be '%v'", name, tc.job.Raw.Name)
-		t.Fail()
+		t.Errorf("Wrong job name '%v' should be '%v'", name, tc.job.Raw.Name)
 	}
 	if description != tc.job.Raw.Description {
-		t.Logf("Wrong job description '%v' should be '%v'", description, tc.job.Raw.Description)
-		t.Fail()
+		t.Errorf("Wrong job description '%v' should be '%v'", description, tc.job.Raw.Description)
 	}
 	if describe != tc.expectedDescribe {
-		t.Logf("Wrong job describe '%v' should be '%v'", describe, tc.expectedDescribe)
-		t.Fail()
+		t.Errorf("Wrong job describe '%v' should be '%v'", describe, tc.expectedDescribe)
 	}
 }

--- a/pkg/job_control/jenkins_test.go
+++ b/pkg/job_control/jenkins_test.go
@@ -71,32 +71,27 @@ func TestParsing(t *testing.T) {
 
 			// Unexpected error happened
 			if test.expectedError == "" && err != nil {
-				t.Logf("Unexpected error %v", err)
-				t.Fail()
+				t.Errorf("Unexpected error %v", err)
 			}
 
 			// Expected error did not happen
 			if test.expectedError != "" && err == nil {
-				t.Logf("Expected error '%v' didn't happen", test.expectedError)
-				t.Fail()
+				t.Errorf("Expected error '%v' didn't happen", test.expectedError)
 			}
 
 			// Job parsing did not match.
 			if job != test.expectedJob {
-				t.Logf("Wrong job parsed '%v' should be '%v'", job, test.expectedJob)
-				t.Fail()
+				t.Errorf("Wrong job parsed '%v' should be '%v'", job, test.expectedJob)
 			}
 
 			// Parsed arguments did not match
 			for expectedName, expectedValue := range test.expectedArgs {
 				value, ok := args[expectedName]
 				if !ok {
-					t.Logf("Missing argument '%v'", expectedName)
-					t.Fail()
+					t.Errorf("Missing argument '%v'", expectedName)
 				}
 				if value != expectedValue {
-					t.Logf("Wrong value '%v' for '%v' should be '%v'", value, expectedName, expectedValue)
-					t.Fail()
+					t.Errorf("Wrong value '%v' for '%v' should be '%v'", value, expectedName, expectedValue)
 				}
 			}
 		})
@@ -126,14 +121,12 @@ func TestLoadReload(t *testing.T) {
 	}
 
 	if j.js.GetJobs().Len() != len(tc.expectedJobs) {
-		t.Logf("Wrong number of jobs loaded %v but expected %v", j.js.GetJobs().Len(), len(tc.expectedJobs))
-		t.Fail()
+		t.Errorf("Wrong number of jobs loaded %v but expected %v", j.js.GetJobs().Len(), len(tc.expectedJobs))
 	}
 	i := 0
 	for job := range tc.expectedJobs {
 		if j.js.GetJob(job).Describe() != tc.expectedJobs[job] {
-			t.Logf("Wrong job loaded %v expected %v", j.js.GetJob(job), tc.expectedJobs[job])
-			t.Fail()
+			t.Errorf("Wrong job loaded %v expected %v", j.js.GetJob(job), tc.expectedJobs[job])
 		}
 		i++
 	}
@@ -143,24 +136,20 @@ func TestLoadReload(t *testing.T) {
 	j.Reload(msg)
 
 	if j.js.GetJobs().Len() != len(tc.expectedJobs) {
-		t.Logf("Wrong number of jobs loaded %v but expected %v", j.js.GetJobs().Len(), len(tc.expectedJobs))
-		t.Fail()
+		t.Errorf("Wrong number of jobs loaded %v but expected %v", j.js.GetJobs().Len(), len(tc.expectedJobs))
 	}
 	i = 0
 	for job := range tc.expectedJobs {
 		if j.js.GetJob(job).Describe() != tc.expectedJobs[job] {
-			t.Logf("Wrong job loaded %v expected %v", j.js.GetJob(job).Name(), tc.expectedJobs[job])
-			t.Fail()
+			t.Errorf("Wrong job loaded %v expected %v", j.js.GetJob(job).Name(), tc.expectedJobs[job])
 		}
 		i++
 	}
 	if len(msg.Replies()) != 1 {
-		t.Logf("Wrong number of replies received %v should be 1", len(msg.Replies()))
-		t.Fail()
+		t.Errorf("Wrong number of replies received %v should be 1", len(msg.Replies()))
 	}
 	if msg.Replies()[0] != tc.expectedReplyOnReload {
-		t.Logf("Wrong reply '%v' should be '%v'", msg.Replies()[0], tc.expectedReplyOnReload)
-		t.Fail()
+		t.Errorf("Wrong reply '%v' should be '%v'", msg.Replies()[0], tc.expectedReplyOnReload)
 	}
 }
 
@@ -183,12 +172,10 @@ func TestDescribe(t *testing.T) {
 	j.Describe(msg)
 
 	if len(msg.Replies()) != 1 {
-		t.Logf("Wrong number of replies %v but expected 1", len(msg.Replies()))
-		t.Fail()
+		t.Errorf("Wrong number of replies %v but expected 1", len(msg.Replies()))
 	}
 	if msg.Replies()[0] != tc.expectedJobs["test"] {
-		t.Logf("Wrong reply '%v' but expected '%v'", msg.Replies()[0], tc.expectedJobs["test"])
-		t.Fail()
+		t.Errorf("Wrong reply '%v' but expected '%v'", msg.Replies()[0], tc.expectedJobs["test"])
 	}
 }
 
@@ -211,13 +198,11 @@ func TestList(t *testing.T) {
 	j.List(msg)
 
 	if len(msg.Replies()) != 1 {
-		t.Logf("Wrong number of replies %v but expected 1", len(msg.Replies()))
-		t.Fail()
+		t.Errorf("Wrong number of replies %v but expected 1", len(msg.Replies()))
 	}
 	for jobName := range tc.expectedJobs {
 		if !strings.Contains(msg.Replies()[0], jobName) {
-			t.Logf("Job named '%v' not found in '%v'", jobName, msg.Replies()[0])
-			t.Fail()
+			t.Errorf("Job named '%v' not found in '%v'", jobName, msg.Replies()[0])
 		}
 	}
 }
@@ -246,13 +231,11 @@ func TestBuild(t *testing.T) {
 	j.Build(msg)
 
 	if len(msg.Replies()) != len(tc.expectedRepliesOnBuild) {
-		t.Logf("Wrong number of replies %v but expected %v", len(msg.Replies()), len(tc.expectedRepliesOnBuild))
-		t.Fail()
+		t.Errorf("Wrong number of replies %v but expected %v", len(msg.Replies()), len(tc.expectedRepliesOnBuild))
 	}
 	for i, reply := range msg.Replies() {
 		if reply != tc.expectedRepliesOnBuild[i] {
-			t.Logf("Wrong reply '%v' but expected '%v'", reply, tc.expectedRepliesOnBuild[i])
-			t.Fail()
+			t.Errorf("Wrong reply '%v' but expected '%v'", reply, tc.expectedRepliesOnBuild[i])
 		}
 	}
 }


### PR DESCRIPTION
This PR makes the tests for `jobcontrol.Job` more similar to the tests
in the slack package.

* **Make Job tests use subtests appropriately**: These now work the
  same as other tests in Synthetic.

* **Improve jenkinsJobTC**: By moving the `gojenkins.Job` creation
  into the test case, the test code is clearer and easier to
  understand. Adding a helper function to calculate expected Describe
  results also makes the tests easier to understand and to write.


* **Add one more test case for Job object**: The new test case
  validates the case in which the job definition includes one
  parameter. I used this to adjust the test in a better and more clear
  way.


* **Use `t.Errorf` instead of `t.Logf` and `t.Fail`**: The `t.Errorf`
  does the same as `t.Logf` and then `t.Fail` and it's one less
  instruction.