### PR TITLE
Try to fix Github Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,26 +5,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
         name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: '^1.16'
       -
         name: Prepare coverage
+        run: |
+          go install github.com/jandelgado/gcov2lcov@latest
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Run tests
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_TOKEN }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && \
           chmod +x ./cc-test-reporter && \
           ./cc-test-reporter before-build && \
-          go get -u github.com/jandelgado/gcov2lcov
-      -
-        name: Run tests
-        run: |
-          go test -v ./... -coverprofile=coverage.out -covermode=atomic && \
+          go test -v ./... -race -coverprofile=coverage.out -covermode=atomic && \
           mkdir -p coverage && \
           gcov2lcov -infile=coverage.out -outfile=coverage/lcov.info
       -
@@ -62,9 +62,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
         name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -72,7 +69,10 @@ jobs:
       -
         name: Install gocyclo
         run: |
-          go get -u github.com/fzipp/gocyclo/cmd/gocyclo@latest
+          go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+      -
+        name: Checkout
+        uses: actions/checkout@v2
       -
         name: Check cyclomatic complexity
         run: |
@@ -81,9 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
         name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -91,7 +88,10 @@ jobs:
       -
         name: Install golint
         run: |
-          go get -u golang.org/x/lint/golint
+          go install golang.org/x/lint/golint@latest
+      -
+        name: Checkout
+        uses: actions/checkout@v2
       -
         name: Check Style
         run: |
@@ -100,9 +100,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
         name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -110,7 +107,10 @@ jobs:
       -
         name: Install ineffassign
         run: |
-          go get -u github.com/gordonklaus/ineffassign
+          go install github.com/gordonklaus/ineffassign@latest
+      -
+        name: Checkout
+        uses: actions/checkout@v2
       -
         name: Download dependencies to local
         run : |
@@ -123,9 +123,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
         name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -133,7 +130,10 @@ jobs:
       -
         name: Install spellchecker
         run: |
-          go get -u github.com/client9/misspell/cmd/misspell
+          go install github.com/client9/misspell/cmd/misspell@latest
+      -
+        name: Checkout
+        uses: actions/checkout@v2
       -
         name: Check spelling
         run: |
@@ -142,9 +142,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
         name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -152,7 +149,10 @@ jobs:
       -
         name: Install staticcheck
         run: |
-          go get -u honnef.co/go/tools/cmd/staticcheck@latest
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+      -
+        name: Checkout
+        uses: actions/checkout@v2
       -
         name: Download dependencies to local
         run : |

--- a/pkg/job_control/jenkins_test.go
+++ b/pkg/job_control/jenkins_test.go
@@ -2,7 +2,7 @@ package jobcontrol
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -13,7 +13,7 @@ import (
 
 func disableLogs() {
 	log.SetFlags(0)
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 type parsingTC struct {

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -2,7 +2,7 @@ package slack
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 	"time"
@@ -14,7 +14,7 @@ import (
 
 func disableLogs() {
 	log.SetFlags(0)
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 }
 
 func TestProcess(t *testing.T) {


### PR DESCRIPTION
The golang version we determine is `^1.16` which effectively means the
latest availabel over 1.16. Therefore, we have the issue that some
changes in newer versions of Go have to be respected now.

The main failure of the actions is related to installing software with
`go get -u`, which is deprecated in favor of `go install` and
completely removed in 1.19 (or maybe earlier). So just replace the
former for the latter.

Another issue is that `go install` changes `go.mod` and `go.sum`, so
we need to do these installations before we checkout the code. Int eh
case of codeclimate, it also means we need to move the installation of
their agent tool to the step after checkout, or the path gets
overwritten.

When installing a tool with `go install`, if outside of a module you
must specify the version of the tool. We fix this by adding `@latest`
to the tools that had it missing to ensure we get the most recent
version of the tools installed.

Remaining failures are: a race condition in the test-suite, as we are
checking for race conditions in tests now, and staticcheck compains of
some deprecated packages from Go 1.16+ that become issues in newer
releases.